### PR TITLE
Fix: Replace defaultProps with JS default parameters

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -3,7 +3,7 @@ import {Pressable, StyleSheet, Platform} from 'react-native';
 import Text from '../text/text';
 import {VARIABLES} from '../../constants/index';
 
-export default function Button({title, textWeight, ...props}) {
+export default function Button({title, textWeight = 'black', ...props}) {
   const [isHover, setIsHover] = useState(false);
   const styles = stylesRef({isHover});
   const onPressIn = () => {
@@ -24,10 +24,6 @@ export default function Button({title, textWeight, ...props}) {
     </Pressable>
   );
 }
-
-Button.defaultProps = {
-  textWeight: 'black',
-};
 
 const stylesRef = ({isHover}) =>
   StyleSheet.create({

--- a/src/components/text/text.js
+++ b/src/components/text/text.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {StyleSheet, Text as RNText} from 'react-native';
 import {TYPOGRAPHY, VARIABLES} from '../../constants/index';
 
-export default function Text({color, size, weight, children, style, ...props}) {
+export default function Text({color = 'LABEL', size = 'normal', weight = 'regular', children, style, ...props}) {
   const styles = stylesRef({color, size, weight});
   return (
     <RNText
@@ -12,12 +12,6 @@ export default function Text({color, size, weight, children, style, ...props}) {
     </RNText>
   );
 }
-
-Text.defaultProps = {
-  color: 'LABEL',
-  size: 'normal',
-  weight: 'regular',
-};
 
 const stylesRef = ({color, size, weight}) =>
   StyleSheet.create({


### PR DESCRIPTION
Fixes these warnings:

>  ERROR  Warning: Text: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    in Text (created by Alertbox)
    in RCTView (created by View)
	...
 > ERROR  Warning: Button: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.
    in Button (created by Alertbox)
    in RCTView (created by View)
	...
    "react-native-alertbox": "https://github.com/hypnokermit/react-native-alertbox",