### PR TITLE
Fix type for AlertBox to ensure it has the fire property available

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,8 @@ export type AlertOptions = {
   fields: FieldProps[];
 };
 
-export declare function AlertBox(): JSX.Element;
+export declare class AlertBox extends React.Component {
+  fire: (options: AlertOptions) => void
+}
 
 export declare function fire(options: AlertOptions): void;


### PR DESCRIPTION
When using multiple AlertBox's, it's necessary to pass a `ref`. It seems like the current typings do not have the correct type for the `ref` property, while also not containing the `fire` property.

This change replaces the type with:

```ts
export declare class AlertBox extends React.Component {
  fire: (options: AlertOptions) => void
}
```

Example usage:

```ts
export default function Product() {
  const alertBoxRef = useRef<AlertBox>(null);

  return (
    <AlertBoxRefContext.Provider value={alertBoxRef}>
      <AlertBox ref={alertBoxRef} />
      <ScrollView>
        <SafeAreaView edges={["bottom"]}>
          <ProductDetail />
        </SafeAreaView>
      </ScrollView>
    </AlertBoxRefContext.Provider>
  );
}
```

```ts
alertBoxRef.current!.fire({
      title: "Delete saved item?",
      message: `Are you sure you want to delete this saved item?`,
      // buttons
      actions: [
        {
          text: "Cancel",
          style: "cancel",
        },
        {
          text: "Delete",
          style: "destructive",
          onPress: async (data) => {
          },
        },
      ],
      // fields
      fields: [],
    });
```